### PR TITLE
Bump addressable gem to 2.5

### DIFF
--- a/kappa.gemspec
+++ b/kappa.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.required_ruby_version = '>= 1.9.3'
   s.add_runtime_dependency 'httparty', '~> 0.13'
-  s.add_runtime_dependency 'addressable', '~> 2.3'
+  s.add_runtime_dependency 'addressable', '~> 2.5'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'webmock', '~> 1.20'
   s.add_development_dependency 'rspec', '~> 3.1'

--- a/lib/kappa/version.rb
+++ b/lib/kappa/version.rb
@@ -1,3 +1,3 @@
 module Twitch
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end

--- a/spec/common/proxy_spec.rb
+++ b/spec/common/proxy_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec'
 require 'yaml'
 require 'kappa'
-require 'common'
+require_relative '../v2/common'
 
 class Real
   def real

--- a/spec/common/status_spec.rb
+++ b/spec/common/status_spec.rb
@@ -1,6 +1,6 @@
 require 'rspec'
 require 'kappa'
-require 'common'
+require_relative '../v2/common'
 
 describe Twitch::Status do
   describe '.map' do

--- a/spec/v2/channel_spec.rb
+++ b/spec/v2/channel_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec'
 require 'yaml'
 require 'kappa'
-require 'common'
+require_relative 'common'
 
 include Twitch::V2
 
@@ -126,7 +126,7 @@ describe Twitch::V2::Channels do
   after do
     WebMock.reset!
   end
- 
+
   describe '#get' do
     it 'creates a Channel from channel name' do
       c = Twitch.channels.get('colminigun')

--- a/spec/v2/common.rb
+++ b/spec/v2/common.rb
@@ -3,9 +3,6 @@ require 'addressable/uri'
 require 'json'
 require 'yaml'
 
-# Force YAML to use newer parsing engine.
-YAML::ENGINE.yamler = 'psych'
-
 def fixture(path)
   File.join(File.dirname(__FILE__), 'fixtures', path)
 end

--- a/spec/v2/configuration_spec.rb
+++ b/spec/v2/configuration_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec'
 require 'yaml'
 require 'kappa'
-require 'common'
+require_relative 'common'
 require 'securerandom'
 require 'webmock/rspec'
 

--- a/spec/v2/connection_spec.rb
+++ b/spec/v2/connection_spec.rb
@@ -1,6 +1,6 @@
 require 'rspec'
 require 'kappa'
-require 'common'
+require_relative 'common'
 
 describe Twitch::Connection do
   after do
@@ -38,7 +38,7 @@ describe Twitch::Connection do
         json = c.get('/test')
       rescue Twitch::Error::FormatError => e
         error = true
-        expect(e.url).to match(/test/) 
+        expect(e.url).to match(/test/)
         expect(e.status).to eq(status)
         expect(e.body).to eq(body)
       end

--- a/spec/v2/game_spec.rb
+++ b/spec/v2/game_spec.rb
@@ -1,6 +1,6 @@
 require 'rspec'
 require 'kappa'
-require 'common'
+require_relative 'common'
 
 include Twitch::V2
 

--- a/spec/v2/images_spec.rb
+++ b/spec/v2/images_spec.rb
@@ -1,6 +1,6 @@
 require 'rspec'
 require 'kappa'
-require 'common'
+require_relative 'common'
 
 include Twitch::V2
 

--- a/spec/v2/stream_spec.rb
+++ b/spec/v2/stream_spec.rb
@@ -1,6 +1,6 @@
 require 'rspec'
 require 'kappa'
-require 'common'
+require_relative 'common'
 
 include Twitch::V2
 
@@ -34,7 +34,7 @@ describe Twitch::V2::Stream do
       expect(c).not_to be_nil
     end
   end
-  
+
   describe '#user' do
     it 'returns the user owning the stream' do
       s = Twitch.streams.get('nathanias')

--- a/spec/v2/team_spec.rb
+++ b/spec/v2/team_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec'
 require 'yaml'
 require 'kappa'
-require 'common'
+require_relative 'common'
 require 'uri'
 
 include Twitch::V2
@@ -55,7 +55,7 @@ describe Twitch::V2::Teams do
   after do
     WebMock.reset!
   end
-  
+
   describe '#get' do
     it 'creates a Team from team name' do
       t = Twitch.teams.get('teamliquid')

--- a/spec/v2/user_spec.rb
+++ b/spec/v2/user_spec.rb
@@ -1,6 +1,6 @@
 require 'rspec'
 require 'kappa'
-require 'common'
+require_relative 'common'
 
 include Twitch::V2
 

--- a/spec/v2/video_spec.rb
+++ b/spec/v2/video_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec'
 require 'webmock/rspec'
 require 'kappa'
-require 'common'
+require_relative 'common'
 
 include Twitch::V2
 


### PR DESCRIPTION
I hit a bundler conflict when trying to use kappa with another gem that required at least version 2.5 of the addressable gem. This branch bumps kappa's addressable dependency to 2.5.

I also hit errors running tests with Ruby 2.2.5, so I fixed them by changing `require 'common'` to use `require_relative`. I fixed another error with Ruby 2.2.5 by omitting the `YAML::ENGINE` override. All tests pass for me locally.